### PR TITLE
Add demo telemetry to family control page

### DIFF
--- a/MinikZekaAI-Web/Views/Platform/AileKontrolu.cshtml
+++ b/MinikZekaAI-Web/Views/Platform/AileKontrolu.cshtml
@@ -1,1 +1,100 @@
-﻿
+﻿<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Tailwind CDN -->
+    <link href="~/css/global.css" rel="stylesheet" />
+    <!-- Inter Font -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+    <link href="~/css/output.css" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="relative bg-yellow-50">
+    <div class="absolute inset-0 z-0 pointer-events-none bg-[radial-gradient(ellipse_at_top_left,_#a5f3fc_30%,_transparent_70%),radial-gradient(ellipse_at_bottom_right,_#fed7aa_30%,_transparent_70%)]"></div>
+    <nav class="sticky top-0 z-70 bg-gray-900 py-2 text-white backdrop-blur-md shadow-xl">
+        <div class="max-w-7xl mx-auto flex items-center justify-between h-[64px] px-4">
+            <div class="hidden md:flex justify-between items-center space-x-5">
+                <img src="/img/MinikZekaAI-Clean.png" alt="Logo" class="h-[72px] rounded-full">
+                <span class="text-white text-2xl font-extrabold" style="font-family: 'Baloo 2', cursive;">MinikZekaAI</span>
+            </div>
+            <div class="flex md:hidden w-full justify-center items-center space-x-2">
+                <img src="/img/MinikZekaAI-Clean.png" alt="Logo" class="h-10 rounded-full">
+                <span class="text-white text-xl font-extrabold" style="font-family: 'Baloo 2', cursive;">MinikZekaAI</span>
+            </div>
+            <div class="flex gap-10">
+                <a href="/Platform/AnaSayfa" class="flex justify-between items-center gap-1 text-white font-bold">
+                    <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M3 9.5L12 4l9 5.5V20a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9.5z" />
+                        <path d="M9 22V12h6v10" />
+                    </svg>
+                    <span>Anasayfa</span>
+                </a>
+                <a href="/Platform/AileKontrolu" class="flex active-underline justify-between items-center gap-2 bg-yellow-300 hover:bg-yellow-400 text-gray-900 rounded-lg px-4 py-2 font-semibold transition">
+                    <svg height="20" width="20" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M7 11a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9zm10.5 4a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0 1a4.5 4.5 0 0 1 4.5 4.5v.5h-9v-.5a4.5 4.5 0 0 1 4.5-4.5zM7 12a5 5 0 0 1 5 5v4H2v-4a5 5 0 0 1 5-5z" />
+                    </svg>
+                    Aile Kontrolü
+                </a>
+            </div>
+        </div>
+    </nav>
+    <main class="flex flex-col flex-1 min-h-[calc(100vh-64px-64px)] py-10 px-5 pb-24">
+        <h1 class="text-2xl font-bold mb-6">Aile Telemetrisi (Demo)</h1>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div class="bg-white rounded-xl shadow p-6">
+                <canvas id="studyChart" height="150"></canvas>
+            </div>
+            <div class="bg-white rounded-xl shadow p-6 overflow-x-auto">
+                <table class="min-w-full text-left">
+                    <thead>
+                        <tr class="border-b">
+                            <th class="py-2">Öğrenci</th>
+                            <th class="py-2">Son Aktivite</th>
+                            <th class="py-2">Toplam Süre (dk)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr class="border-b">
+                            <td class="py-2">Ayşe</td>
+                            <td class="py-2">09:30</td>
+                            <td class="py-2">45</td>
+                        </tr>
+                        <tr class="border-b">
+                            <td class="py-2">Mehmet</td>
+                            <td class="py-2">09:15</td>
+                            <td class="py-2">30</td>
+                        </tr>
+                        <tr>
+                            <td class="py-2">Zeynep</td>
+                            <td class="py-2">08:50</td>
+                            <td class="py-2">60</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+    <script>
+        const ctx = document.getElementById('studyChart').getContext('2d');
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: ['Ayşe', 'Mehmet', 'Zeynep'],
+                datasets: [{
+                    label: 'Günlük Çalışma (dk)',
+                    data: [45, 30, 60],
+                    backgroundColor: ['#F59E0B', '#3B82F6', '#EF4444']
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { position: 'bottom' }
+                }
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement demo telemetry view with navigation, table of sample family data, and bar chart

## Testing
- `dotnet build`
- `npm run tw:build`


------
https://chatgpt.com/codex/tasks/task_e_689399dcb2e883209510001749a624a8